### PR TITLE
Fix: PHP 7.4 cli logs in stderr output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: php
 
 php:
+  - 7.2
   - 7.3
   - 7.4
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: php
 
 php:
-  - 7.2
   - 7.3
+  - 7.4
 
 before_script:
   - composer install

--- a/src/Server.php
+++ b/src/Server.php
@@ -114,4 +114,46 @@ class Server extends Process
             }
         }
     }
+
+    public function getIncrementalErrorOutput()
+    {
+        return self::cleanErrorOutput(parent::getIncrementalErrorOutput());
+    }
+
+    public function getErrorOutput()
+    {
+        return self::cleanErrorOutput(parent::getErrorOutput());
+    }
+
+    public static function cleanErrorOutput($output)
+    {
+        if (!trim($output)) {
+            return '';
+        }
+
+        $errorLines = [];
+
+        foreach (explode(PHP_EOL, $output) as $line) {
+            if (!$line) {
+                continue;
+            }
+
+            if (!self::stringEndsWithAny($line, ['Accepted', 'Closing', ' started'])) {
+                $errorLines[] = $line;
+            }
+        }
+
+        return $errorLines ? implode(PHP_EOL, $errorLines) : '';
+    }
+
+    private static function stringEndsWithAny($haystack, array $needles)
+    {
+        foreach ($needles as $needle) {
+            if (substr($haystack, (-1 * strlen($needle))) === $needle) {
+                return true;
+            }
+        }
+
+        return false;
+    }
 }

--- a/src/Server.php
+++ b/src/Server.php
@@ -125,7 +125,7 @@ class Server extends Process
         return self::cleanErrorOutput(parent::getErrorOutput());
     }
 
-    public static function cleanErrorOutput($output)
+    private static function cleanErrorOutput($output)
     {
         if (!trim($output)) {
             return '';

--- a/tests/AppIntegrationTest.php
+++ b/tests/AppIntegrationTest.php
@@ -235,6 +235,19 @@ class AppIntegrationTest extends AbstractTestCase
         $this->assertSame('second', $this->client->get('/')->getBody()->getContents());
     }
 
+    public function testServerLogsAreNotInErrorOutput()
+    {
+        $expectedErrorOutput = '[Sun Feb 23 10:18:43 2020] [::1]:55146 [404]: (null) / - No such file or directory';
+        $serverLogsExample = '[Sun Feb 23 10:18:31 2020] PHP 7.4.2 Development Server (http://localhost:8086) started' . PHP_EOL .
+                             '[Sun Feb 23 10:18:43 2020] [::1]:55146 Accepted' . PHP_EOL .
+                             $expectedErrorOutput . PHP_EOL .
+                             '[Sun Feb 23 10:18:43 2020] [::1]:55146 Closing' . PHP_EOL;
+
+        $cleanedServerLogs = Server::cleanErrorOutput($serverLogsExample);
+
+        $this->assertEquals($expectedErrorOutput, $cleanedServerLogs);
+    }
+
     private function parseRequestFromResponse(ResponseInterface $response)
     {
         $body = unserialize($response->getBody());

--- a/tests/AppIntegrationTest.php
+++ b/tests/AppIntegrationTest.php
@@ -237,15 +237,18 @@ class AppIntegrationTest extends AbstractTestCase
 
     public function testServerLogsAreNotInErrorOutput()
     {
-        $expectedErrorOutput = '[Sun Feb 23 10:18:43 2020] [::1]:55146 [404]: (null) / - No such file or directory';
-        $serverLogsExample = '[Sun Feb 23 10:18:31 2020] PHP 7.4.2 Development Server (http://localhost:8086) started' . PHP_EOL .
-                             '[Sun Feb 23 10:18:43 2020] [::1]:55146 Accepted' . PHP_EOL .
-                             $expectedErrorOutput . PHP_EOL .
-                             '[Sun Feb 23 10:18:43 2020] [::1]:55146 Closing' . PHP_EOL;
+        $this->client->delete('/_all');
 
-        $cleanedServerLogs = Server::cleanErrorOutput($serverLogsExample);
+        $expectedServerErrorOutput = '[404]: (null) / - No such file or directory';
 
-        $this->assertEquals($expectedErrorOutput, $cleanedServerLogs);
+        self::$server1->addErrorOutput('PHP 7.4.2 Development Server (http://localhost:8086) started' . PHP_EOL);
+        self::$server1->addErrorOutput('Accepted' . PHP_EOL);
+        self::$server1->addErrorOutput($expectedServerErrorOutput . PHP_EOL);
+        self::$server1->addErrorOutput('Closing' . PHP_EOL);
+
+        $actualServerErrorOutput = self::$server1->getErrorOutput();
+
+        $this->assertEquals($expectedServerErrorOutput, $actualServerErrorOutput);
     }
 
     private function parseRequestFromResponse(ResponseInterface $response)


### PR DESCRIPTION
I'm writing this PR to present a small patch to handle a new behavior of the PHP 7.4 CLI: it is attaching log messages of the built-in PHP server (`php -S`) to the `stderr` pipe.

Moreover, I opened an issue to discuss this problem with the guys from `internations/http-mock` (https://github.com/InterNations/http-mock/issues/53). At a first glance I thought it wasn't a problem of http mock itself but since this behavior was introduced only in PHP 7.4, they found feasible the idea of adding a patch to get the library working with the new version of PHP.

Since there isn't a builtin CLI option to change this behavior, I'm presenting the same solution here.

Let me know what you think of this approach to tackle this issue.

If you have a better solution in mind, I'll be glad to hear and discuss more about it! 😃 